### PR TITLE
2차원 배열이 아니라 rust_3d::Mesh3D 를 생성

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "lazy_static",
  "nalgebra",
  "ndarray",
+ "rust-3d",
  "serde",
  "terrain",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+dependencies = [
+ "either",
+ "radium",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +222,12 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -410,7 +426,7 @@ dependencies = [
  "approx",
  "matrixmultiply",
  "nalgebra-macros",
- "num-complex",
+ "num-complex 0.4.2",
  "num-rational 0.4.1",
  "num-traits",
  "simba",
@@ -435,7 +451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec23e6762830658d2b3d385a75aa212af2f67a4586d4442907144f3bb6a1ca8"
 dependencies = [
  "matrixmultiply",
- "num-complex",
+ "num-complex 0.4.2",
  "num-integer",
  "num-traits",
  "rawpointer",
@@ -460,6 +476,41 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -488,6 +539,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -580,6 +643,12 @@ checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -698,6 +767,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
+name = "rust-3d"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce1e81ec1eec57188d13fdeb9fcdf961914eb0f57e3b40c723be3b9245de9bb"
+dependencies = [
+ "bitvec",
+ "fnv",
+ "num",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a2609e876d4f77f6ab7ff5254fc39b4f1927ba8e6db3d18be7c32534d3725e"
 dependencies = [
  "approx",
- "num-complex",
+ "num-complex 0.4.2",
  "num-traits",
  "paste",
  "wide",
@@ -828,6 +908,7 @@ dependencies = [
  "getrandom 0.2.7",
  "noise",
  "rand 0.8.5",
+ "rust-3d",
 ]
 
 [[package]]

--- a/core/src/combinations/terrain/mod.rs
+++ b/core/src/combinations/terrain/mod.rs
@@ -1,8 +1,6 @@
+use specs::{Builder, DispatcherBuilder, WorldExt};
 
-use specs::{WorldExt, Builder, DispatcherBuilder};
-
-use crate::{combinations::{ Combination }, components, systems};
-
+use crate::{combinations::Combination, components, systems};
 
 pub struct TerrainCombination;
 impl Combination for TerrainCombination {
@@ -12,10 +10,20 @@ impl Combination for TerrainCombination {
 
         // MEMO: Terrain에서 entity는 쓰이지 않으나, 예시로 남겨둡니다.
         // // entities (build)
-        let terrain = world.create_entity().with(components::terrain::Terrain { bitmap: terrain::test_runner1().unwrap() }).build();
-        
+        let terrain = world
+            .create_entity()
+            .with(components::terrain::Terrain {
+                bitmap: terrain::test_runner1().unwrap(),
+                mesh: terrain::gen_mesh().unwrap(),
+            })
+            .build();
+
         DispatcherBuilder::new()
-            .with(systems::renders::terrain::RenderTerrainSystem {}, "render_terrain_system", &[])
+            .with(
+                systems::renders::terrain::RenderTerrainSystem {},
+                "render_terrain_system",
+                &[],
+            )
             .build()
     }
 }

--- a/core/src/components/terrain/mod.rs
+++ b/core/src/components/terrain/mod.rs
@@ -1,8 +1,10 @@
-use specs::{VecStorage, Component};
+use specs::{Component, VecStorage};
 use terrain::model::pixel::Pixel;
+use terrain::*;
 
 #[derive(Component, Debug)]
 #[storage(VecStorage)]
 pub struct Terrain {
-    pub bitmap: Vec<Vec<Pixel>>
+    pub bitmap: Vec<Vec<Pixel>>,
+    pub mesh: Mesh,
 }

--- a/core/src/systems/renders/terrain/mod.rs
+++ b/core/src/systems/renders/terrain/mod.rs
@@ -16,7 +16,7 @@ impl<'a> System<'a> for RenderTerrainSystem {
             gui::webgl::buffer::init::bind_color_buffer(&GUI_BASICS.context, &GUI_BASICS.program);
             gui::webgl::buffer::update::set_color(&GUI_BASICS.context, &terrain.bitmap);
             gui::webgl::buffer::init::bind_vertex_buffer(&GUI_BASICS.context, &GUI_BASICS.program);
-            gui::webgl::buffer::update::set_rectangle(&GUI_BASICS.context, &terrain.bitmap, &GUI_BASICS.program, &GUI_BASICS.ranges);
+            gui::webgl::buffer::update::set_rectangle(&GUI_BASICS.context, &terrain.mesh, &terrain.bitmap, &GUI_BASICS.program, &GUI_BASICS.ranges);
         }
     }
 }

--- a/core/src/systems/renders/terrain/mod.rs
+++ b/core/src/systems/renders/terrain/mod.rs
@@ -16,7 +16,7 @@ impl<'a> System<'a> for RenderTerrainSystem {
             gui::webgl::buffer::init::bind_color_buffer(&GUI_BASICS.context, &GUI_BASICS.program);
             gui::webgl::buffer::update::set_color(&GUI_BASICS.context, &terrain.bitmap);
             gui::webgl::buffer::init::bind_vertex_buffer(&GUI_BASICS.context, &GUI_BASICS.program);
-            gui::webgl::buffer::update::set_rectangle(&GUI_BASICS.context, &terrain.mesh, &terrain.bitmap, &GUI_BASICS.program, &GUI_BASICS.ranges);
+            gui::webgl::buffer::update::set_rectangle(&GUI_BASICS.context, &terrain.mesh,  &GUI_BASICS.program, &GUI_BASICS.ranges);
         }
     }
 }

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -13,6 +13,7 @@ wasm-bindgen = "0.2.81"
 ndarray = "0.15.4"
 nalgebra = "0.31.0"
 lazy_static = "1.4.0"
+rust-3d="0.34"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/gui/src/webgl/buffer/update.rs
+++ b/gui/src/webgl/buffer/update.rs
@@ -117,7 +117,7 @@ pub fn set_rectangle(context: &WebGl2RenderingContext, mesh: &Mesh, program: &We
                 let y = start_height_ratio + point.y as f32 * height_ratio;
                 vertices.push(x);
                 vertices.push(y);
-                vertices.push(point.z as f32);
+                vertices.push(point.height as f32);
             }
         }
     }

--- a/gui/src/webgl/buffer/update.rs
+++ b/gui/src/webgl/buffer/update.rs
@@ -40,24 +40,31 @@ pub fn set_color(context: &WebGl2RenderingContext, bitmap: &Vec<Vec<Pixel>>) {
     }
 }
 
-pub fn set_rectangle(context: &WebGl2RenderingContext, mesh: &Mesh, bitmap: &Vec<Vec<Pixel>>, program: &WebGlProgram, camera_rad_inputs: &[HtmlInputElement; 4]) {
-    if bitmap.is_empty() {
-        return;
-    }
-    if bitmap[0].is_empty() {
+pub fn set_rectangle(context: &WebGl2RenderingContext, mesh: &Mesh, program: &WebGlProgram, camera_rad_inputs: &[HtmlInputElement; 4]) {
+    if mesh.num_faces() == 0 {
         return;
     }
 
-    let width = bitmap.len() - 1;
-    let height = bitmap[0].len() - 1;
+    // reasonable defaults?
+    let mut width_ratio = 1f32;
+    let mut height_ratio = 1f32;
 
-    let width_ratio = 2. / width as f32;
-    let height_ratio = 2. / height as f32;
+    let start_width_ratio = -1f32;
+    let start_height_ratio = -1f32;    
 
-    let start_width_ratio = -1.;
-    let start_height_ratio = -1.;
+    
 
-    let mut vertices = Vec::<f32>::with_capacity((width * height * 18) as usize);
+    if let Ok(bounding_box) = mesh.bounding_box_maybe() {
+        let max = bounding_box.max_p();
+        let min = bounding_box.min_p();
+        let width = max.x - min.x;
+        let height = max.y - min.y;
+
+        width_ratio = 2. / width as f32;
+        height_ratio = 2. / height as f32;
+    }
+
+    let mut vertices: Vec<f32> = Vec::with_capacity(mesh.num_faces() * 9);
 
     let camera_rads = camera_rad_inputs.clone().map(|node| {
         let value = node.value();

--- a/terrain/Cargo.toml
+++ b/terrain/Cargo.toml
@@ -10,3 +10,4 @@ noise = "0.7"
 csv = "1.1"
 rand = "0.8"
 getrandom = { version = "0.2", features = ["js"] }
+rust-3d="0.34"

--- a/terrain/src/data_structures/mod.rs
+++ b/terrain/src/data_structures/mod.rs
@@ -1,0 +1,2 @@
+pub mod pixel_3d;
+pub use pixel_3d::*;

--- a/terrain/src/data_structures/pixel_3d.rs
+++ b/terrain/src/data_structures/pixel_3d.rs
@@ -1,0 +1,155 @@
+use std::{
+    cmp::Ordering,
+    hash::{Hash, Hasher},
+};
+
+use rust_3d::*;
+
+use crate::model::pixel::Pixel;
+#[derive(Default, Debug, PartialEq, PartialOrd, Clone)]
+pub struct Pixel3D {
+    pub x: f64,
+    pub y: f64,
+    pub height: f64,
+    pub moisture: f64,
+    pub habitance: bool,
+}
+
+impl Pixel3D {
+    pub fn new(x: f64, y: f64, pixel: &Pixel) -> Self {
+        Pixel3D {
+            x,
+            y,
+            height: pixel.height,
+            moisture: pixel.moisture,
+            habitance: pixel.habitance,
+        }
+    }
+}
+
+impl Eq for Pixel3D {}
+
+impl Ord for Pixel3D {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let origin = Pixel3D::default();
+        sqr_dist_3d(&origin, self)
+            .partial_cmp(&sqr_dist_3d(&origin, other))
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+impl IsND for Pixel3D {
+    fn n_dimensions() -> usize {
+        3
+    }
+
+    fn position_nd(&self, dimension: usize) -> Result<f64> {
+        match dimension {
+            0 => Ok(self.x),
+            1 => Ok(self.y),
+            2 => Ok(self.height),
+            _ => Err(ErrorKind::IncorrectDimension),
+        }
+    }
+}
+impl Is3D for Pixel3D {
+    #[inline(always)]
+    fn x(&self) -> f64 {
+        self.x
+    }
+    #[inline(always)]
+    fn y(&self) -> f64 {
+        self.y
+    }
+    #[inline(always)]
+    fn z(&self) -> f64 {
+        self.height
+    }
+}
+
+impl IsBuildableND for Pixel3D {
+    fn new_nd(coords: &[f64]) -> Result<Self> {
+        if coords.len() != 3 {
+            return Err(ErrorKind::DimensionsDontMatch);
+        }
+        Ok(Pixel3D {
+            x: coords[0],
+            y: coords[1],
+            height: coords[2],
+            moisture: 0f64,
+            habitance: true,
+        })
+    }
+
+    fn from_nd<P>(&mut self, other: P) -> Result<()>
+    where
+        P: IsBuildableND,
+    {
+        if P::n_dimensions() != 3 {
+            return Err(ErrorKind::DimensionsDontMatch);
+        }
+
+        self.x = other.position_nd(0)?;
+        self.y = other.position_nd(1)?;
+        self.height = other.position_nd(2)?;
+        Ok(())
+    }
+}
+
+impl Hash for Pixel3D {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.x.to_bits().hash(state);
+        self.y.to_bits().hash(state);
+        self.height.to_bits().hash(state);
+    }
+}
+
+impl IsBuildable3D for Pixel3D {
+    fn new(x: f64, y: f64, z: f64) -> Self {
+        Pixel3D {
+            x,
+            y,
+            height: z,
+            moisture: 0f64,
+            habitance: true,
+        }
+    }
+
+    fn from<P>(&mut self, other: &P)
+    where
+        P: Is3D,
+    {
+        self.x = other.x();
+        self.y = other.y();
+        self.height = other.z();
+    }
+}
+
+impl IsEditableND for Pixel3D {
+    fn set_position(&mut self, dimension: usize, val: f64) -> Result<()> {
+        match dimension {
+            0 => self.x = val,
+            1 => self.y = val,
+            2 => self.height = val,
+            _ => return Err(ErrorKind::DimensionsDontMatch),
+        }
+        Ok(())
+    }
+}
+
+impl IsEditable3D for Pixel3D {
+    #[inline(always)]
+    fn set_x(&mut self, val: f64) {
+        self.x = val;
+    }
+
+    #[inline(always)]
+    fn set_y(&mut self, val: f64) {
+        self.y = val;
+    }
+
+    #[inline(always)]
+    fn set_z(&mut self, val: f64) {
+        self.height = val;
+    }
+}

--- a/terrain/src/gen.rs
+++ b/terrain/src/gen.rs
@@ -1,0 +1,66 @@
+use crate::model;
+use model::noise_param::*;
+use model::pixel::*;
+use model::terrain::*;
+
+use rust_3d::*;
+
+pub enum Result<T> {
+    Ok(T),
+    Err(String),
+}
+
+pub type Mesh = Mesh3D<Point3D, PointCloud3D<Point3D>, Vec<usize>>;
+
+pub fn gen_bitmap() -> Option<Vec<Vec<Pixel>>> {
+    const WIDTH: usize = 100;
+    const HEIGHT: usize = 100;
+    const SCALE: f64 = (WIDTH + HEIGHT) as f64 * 0.1347;
+
+    let mut terrain = Terrain::make_terrain(WIDTH, HEIGHT, SCALE);
+
+    let noise_height_layer = NoiseParam::make_noise(0.5, 2f32, 3, 2400);
+    let noise_moisture_layer = NoiseParam::make_noise(0.25, 2f32, 3, 2400);
+
+    terrain.generate_height_layer(noise_height_layer);
+    terrain.generate_moisture_layer(noise_moisture_layer);
+
+    terrain.get_pixel_map()
+}
+
+pub fn gen_mesh() -> Option<Mesh> {
+    let mut mesh = Mesh3D::default();
+    let terrain = gen_bitmap();
+    if let Some(terrain) = terrain {
+        let width = terrain.len();
+        let height = terrain[0].len();
+        for (r, row) in terrain.iter().enumerate() {
+            for (c, pixel) in row.iter().enumerate() {
+                let x = r as f64;
+                let y = c as f64;
+                let z = pixel.height;
+                mesh.add_vertex(Point3D::new(x, y, z));
+            }
+        }
+        for r in 0..width - 1 {
+            for c in 0..height - 1 {
+                let top_left = r * width + c;
+                let top_right = top_left + 1;
+                let bottom_left = top_left + width;
+                let bottom_right = bottom_left + 1;
+                let top_left = VId { val: top_left };
+                let top_right = VId { val: top_right };
+                let bottom_left = VId { val: bottom_left };
+                let bottom_right = VId { val: bottom_right };
+                mesh.try_add_connection(top_left, bottom_right, top_right)
+                    .unwrap_or(FId { val: 0 });
+                // 아무 의미 없고, 워닝 누르기 위한 unwrap
+                mesh.try_add_connection(top_left, bottom_left, bottom_right)
+                    .unwrap_or(FId { val: 0 });
+            }
+        }
+        Some(mesh)
+    } else {
+        None
+    }
+}

--- a/terrain/src/gen.rs
+++ b/terrain/src/gen.rs
@@ -1,3 +1,4 @@
+use crate::data_structures::Pixel3D;
 use crate::model;
 use model::noise_param::*;
 use model::pixel::*;
@@ -10,7 +11,7 @@ pub enum Result<T> {
     Err(String),
 }
 
-pub type Mesh = Mesh3D<Point3D, PointCloud3D<Point3D>, Vec<usize>>;
+pub type Mesh = Mesh3D<Pixel3D, PointCloud3D<Pixel3D>, Vec<usize>>;
 
 pub fn gen_bitmap() -> Option<Vec<Vec<Pixel>>> {
     const WIDTH: usize = 100;
@@ -38,8 +39,7 @@ pub fn gen_mesh() -> Option<Mesh> {
             for (c, pixel) in row.iter().enumerate() {
                 let x = r as f64;
                 let y = c as f64;
-                let z = pixel.height;
-                mesh.add_vertex(Point3D::new(x, y, z));
+                mesh.add_vertex(Pixel3D::new(x, y, &pixel));
             }
         }
         for r in 0..width - 1 {

--- a/terrain/src/lib.rs
+++ b/terrain/src/lib.rs
@@ -7,8 +7,6 @@ pub mod model;
 
 pub mod gen;
 
-pub use rust_3d::*;
-
 pub use gen::*;
 
 pub fn test_runner1() -> Option<Vec<Vec<Pixel>>> {

--- a/terrain/src/lib.rs
+++ b/terrain/src/lib.rs
@@ -3,6 +3,7 @@ use model::noise_param::NoiseParam;
 use model::pixel::Pixel;
 use model::terrain::Terrain;
 
+pub mod data_structures;
 pub mod model;
 
 pub mod gen;

--- a/terrain/src/lib.rs
+++ b/terrain/src/lib.rs
@@ -5,6 +5,12 @@ use model::terrain::Terrain;
 
 pub mod model;
 
+pub mod gen;
+
+pub use rust_3d::*;
+
+pub use gen::*;
+
 pub fn test_runner1() -> Option<Vec<Vec<Pixel>>> {
     const WIDTH: usize = 100;
     const HEIGHT: usize = 100;


### PR DESCRIPTION
rust_3d::Mesh3D를 미리 만들어서 반환하도록 `terrain` crate에 함수를 추가했습니다.

- `core` crate가 `rust_3d`를 dependency로 가지지 않을 수 있도록 `pub use rust_3d::*`를 추가했는데 다시 생각해보니 좋은 아이디어가 아닌 것 같아서 다음 커밋에서 삭제할 예정
- 대신 `terrain::Mesh` typealias는 유지하겠습니다.
- core 쪽에서 건드린 두 개 파일의 예시 코드를 보시면 어떻게 생겼는지 아실 수 있을거에요